### PR TITLE
Create study room functionality

### DIFF
--- a/client/src/graphql/Classes.ts
+++ b/client/src/graphql/Classes.ts
@@ -23,7 +23,9 @@ export interface Classes_me_groups_ClassGroup {
   users: Classes_me_groups_ClassGroup_users[];
 }
 
-export type Classes_me_groups = Classes_me_groups_CourseGroup | Classes_me_groups_ClassGroup;
+export type Classes_me_groups =
+  | Classes_me_groups_CourseGroup
+  | Classes_me_groups_ClassGroup;
 
 export interface Classes_me {
   __typename: "User";

--- a/client/src/graphql/Contacts.ts
+++ b/client/src/graphql/Contacts.ts
@@ -23,7 +23,9 @@ export interface Contacts_me_groups_DMGroup {
   users: Contacts_me_groups_DMGroup_users[];
 }
 
-export type Contacts_me_groups = Contacts_me_groups_ClassGroup | Contacts_me_groups_DMGroup;
+export type Contacts_me_groups =
+  | Contacts_me_groups_ClassGroup
+  | Contacts_me_groups_DMGroup;
 
 export interface Contacts_me {
   __typename: "User";

--- a/client/src/graphql/GetNode.ts
+++ b/client/src/graphql/GetNode.ts
@@ -72,7 +72,10 @@ export interface GetNode_node_FolderNode_children_FolderNode {
   title: string;
 }
 
-export type GetNode_node_FolderNode_children = GetNode_node_FolderNode_children_TextNode | GetNode_node_FolderNode_children_HeadingNode | GetNode_node_FolderNode_children_FolderNode;
+export type GetNode_node_FolderNode_children =
+  | GetNode_node_FolderNode_children_TextNode
+  | GetNode_node_FolderNode_children_HeadingNode
+  | GetNode_node_FolderNode_children_FolderNode;
 
 export interface GetNode_node_FolderNode {
   __typename: "FolderNode";
@@ -82,7 +85,10 @@ export interface GetNode_node_FolderNode {
   children: GetNode_node_FolderNode_children[];
 }
 
-export type GetNode_node = GetNode_node_TextNode | GetNode_node_HeadingNode | GetNode_node_FolderNode;
+export type GetNode_node =
+  | GetNode_node_TextNode
+  | GetNode_node_HeadingNode
+  | GetNode_node_FolderNode;
 
 export interface GetNode {
   node: GetNode_node | null;

--- a/client/src/graphql/MyCalendar.ts
+++ b/client/src/graphql/MyCalendar.ts
@@ -20,7 +20,9 @@ export interface MyCalendar_me_groups_ClassGroup {
   type: string;
 }
 
-export type MyCalendar_me_groups = MyCalendar_me_groups_CourseGroup | MyCalendar_me_groups_ClassGroup;
+export type MyCalendar_me_groups =
+  | MyCalendar_me_groups_CourseGroup
+  | MyCalendar_me_groups_ClassGroup;
 
 export interface MyCalendar_me {
   __typename: "User";

--- a/client/src/graphql/MyGroups.ts
+++ b/client/src/graphql/MyGroups.ts
@@ -63,7 +63,11 @@ export interface MyGroups_me_groups_StudyGroup {
   users: MyGroups_me_groups_StudyGroup_users[];
 }
 
-export type MyGroups_me_groups = MyGroups_me_groups_DMGroup | MyGroups_me_groups_ClassGroup | MyGroups_me_groups_CourseGroup | MyGroups_me_groups_StudyGroup;
+export type MyGroups_me_groups =
+  | MyGroups_me_groups_DMGroup
+  | MyGroups_me_groups_ClassGroup
+  | MyGroups_me_groups_CourseGroup
+  | MyGroups_me_groups_StudyGroup;
 
 export interface MyGroups_me {
   __typename: "User";

--- a/client/src/modules/StudyRooms/Explore.tsx
+++ b/client/src/modules/StudyRooms/Explore.tsx
@@ -92,7 +92,11 @@ const joinStudyGroupMutation = gql`
 `;
 
 const addStudyGroup = gql`
-  mutation AddStudyGroup($uids: [String!]!, $isPublic: Boolean!, $groupName: String!) {
+  mutation AddStudyGroup(
+    $uids: [String!]!
+    $isPublic: Boolean!
+    $groupName: String!
+  ) {
     addStudyGroup(uids: $uids, isPublic: $isPublic, groupName: $groupName) {
       id
     }
@@ -152,9 +156,11 @@ const PopUp = (props: any) => {
   const handleCreate = () => {
     let uids = selectedContacts.map((c: any) => c.users.slice(-1)[0].id);
     uids.push(uid);
-    createStudyRoom({ variables: { uids: uids, groupName: studyRoomName, isPublic: isPublic } });
+    createStudyRoom({
+      variables: { uids: uids, groupName: studyRoomName, isPublic: isPublic },
+    });
     handleClose();
-  }
+  };
 
   const classes = useStyles();
 
@@ -210,8 +216,7 @@ const PopUp = (props: any) => {
                   checked={isPublic}
                   onChange={(e: ChangeEvent<HTMLInputElement>) => {
                     setIsPublic(e.target.checked);
-                  }
-                  }
+                  }}
                   name="isPublic"
                   color="primary"
                 />


### PR DESCRIPTION
Study rooms can now be created under the "Explore" tab.

Things to fix:
- The actual code needs types & stuff but for now it's functional & is enough for testing
- If the user is already in a public study group, it shouldn't show up in "Explore" tab
- Once the user clicks "Create" it should take them to the contacts page and directly to the contact that corresponds to the group that they just created.